### PR TITLE
Fix audit comments

### DIFF
--- a/allowances/contracts/AlowanceModule.sol
+++ b/allowances/contracts/AlowanceModule.sol
@@ -305,7 +305,7 @@ contract AllowanceModule is SignatureDecoder {
         require(index != uint(0), "index != uint(0)");
         address currentDelegate = delegates[msg.sender][index].delegate;
         if(currentDelegate != address(0)) {
-            // We have a collision for the indeces of delegates
+            // We have a collision for the indices of delegates
             require(currentDelegate == delegate, "currentDelegate == delegate");
             // Delegate already exists, nothing to do
             return;

--- a/allowances/contracts/AlowanceModule.sol
+++ b/allowances/contracts/AlowanceModule.sol
@@ -73,6 +73,7 @@ contract AllowanceModule is SignatureDecoder {
     function setAllowance(address delegate, address token, uint96 allowanceAmount, uint16 resetTimeMin, uint32 resetBaseMin)
         public
     {
+        require(delegate != address(0), "delegate != address(0)");
         require(delegates[msg.sender][uint48(delegate)].delegate == delegate, "delegates[msg.sender][uint48(delegate)].delegate == delegate");
         Allowance memory allowance = getAllowance(msg.sender, delegate, token);
         if (allowance.nonce == 0) { // New token
@@ -159,7 +160,7 @@ contract AllowanceModule is SignatureDecoder {
         // Get current state
         Allowance memory allowance = getAllowance(address(safe), delegate, token);
         bytes memory transferHashData = generateTransferHashData(address(safe), token, to, amount, paymentToken, payment, allowance.nonce);
-        
+
         // Update state
         allowance.nonce = allowance.nonce + 1;
         uint96 newSpent = allowance.spent + amount;
@@ -186,6 +187,7 @@ contract AllowanceModule is SignatureDecoder {
             // Transfer payment
             // solium-disable-next-line security/no-tx-origin
             transfer(safe, paymentToken, tx.origin, payment);
+            // solium-disable-next-line security/no-tx-origin
             emit PayAllowanceTransfer(address(safe), delegate, paymentToken, tx.origin, payment);
         }
         // Transfer token
@@ -196,6 +198,7 @@ contract AllowanceModule is SignatureDecoder {
     /// @dev Returns the chain id used by this contract.
     function getChainId() public pure returns (uint256) {
         uint256 id;
+        // solium-disable-next-line security/no-inline-assembly
         assembly {
             id := chainid()
         }
@@ -266,6 +269,8 @@ contract AllowanceModule is SignatureDecoder {
             // Use ecrecover with the messageHash for EOA signatures
             owner = ecrecover(keccak256(transferHashData), v, r, s);
         }
+        // 0 for the recovered owner indicates that an error happened.
+        require(owner != address(0), "owner != address(0)");
     }
 
     function transfer(GnosisSafe safe, address token, address payable to, uint96 amount) private {
@@ -296,11 +301,11 @@ contract AllowanceModule is SignatureDecoder {
     /// @dev Allows to add a delegate.
     /// @param delegate Delegate that should be added.
     function addDelegate(address delegate) public {
-        require(delegate != address(0), "Invalid delegate address");
         uint48 index = uint48(delegate);
+        require(index != uint(0), "index != uint(0)");
         address currentDelegate = delegates[msg.sender][index].delegate;
         if(currentDelegate != address(0)) {
-            // We have a collision for the indeces of delegates 
+            // We have a collision for the indeces of delegates
             require(currentDelegate == delegate, "currentDelegate == delegate");
             // Delegate already exists, nothing to do
             return;
@@ -333,8 +338,15 @@ contract AllowanceModule is SignatureDecoder {
                 emit DeleteAllowance(msg.sender, delegate, token);
             }
         }
-        delegates[msg.sender][current.prev].next = current.next;
-        delegates[msg.sender][current.next].prev = current.prev;
+        if (current.prev == 0) {
+            delegatesStart[msg.sender] = current.next;
+        } else {
+            delegates[msg.sender][current.prev].next = current.next;
+        }
+        if (current.next != 0) {
+            delegates[msg.sender][current.next].prev = current.prev;
+        }
+        delete delegates[msg.sender][uint48(delegate)];
         emit RemoveDelegate(msg.sender, delegate);
     }
 

--- a/allowances/test/allowanceManagement.js
+++ b/allowances/test/allowanceManagement.js
@@ -1,0 +1,175 @@
+const utils = require('@gnosis.pm/safe-contracts/test/utils/general')
+
+const truffleContract = require("@truffle/contract")
+
+const GnosisSafeBuildInfo = require("@gnosis.pm/safe-contracts/build/contracts/GnosisSafe.json")
+const GnosisSafe = truffleContract(GnosisSafeBuildInfo)
+GnosisSafe.setProvider(web3.currentProvider)
+const GnosisSafeProxyBuildInfo = require("@gnosis.pm/safe-contracts/build/contracts/GnosisSafeProxy.json")
+const GnosisSafeProxy = truffleContract(GnosisSafeProxyBuildInfo)
+GnosisSafeProxy.setProvider(web3.currentProvider)
+
+const AllowanceModule = artifacts.require("./AllowanceModule.sol")
+const TestToken = artifacts.require("./TestToken.sol")
+
+contract('AllowanceModule delegate', function(accounts) {
+    let lw
+    let gnosisSafe
+    let safeModule
+
+    const CALL = 0
+    const ADDRESS_0 = "0x0000000000000000000000000000000000000000"
+
+    beforeEach(async function() {
+        // Create lightwallet
+        lw = await utils.createLightwallet()
+
+        // Create Master Copies
+        safeModule = await AllowanceModule.new()
+
+        const gnosisSafeMasterCopy = await GnosisSafe.new({ from: accounts[0] })
+        const proxy = await GnosisSafeProxy.new(gnosisSafeMasterCopy.address, { from: accounts[0] })
+        gnosisSafe = await GnosisSafe.at(proxy.address)
+        await gnosisSafe.setup([lw.accounts[0], lw.accounts[1], accounts[1]], 2, ADDRESS_0, "0x", ADDRESS_0, ADDRESS_0, 0, ADDRESS_0, { from: accounts[0] })
+    })
+
+    let execTransaction = async function(to, value, data, operation, message) {
+        let nonce = await gnosisSafe.nonce()
+        let transactionHash = await gnosisSafe.getTransactionHash(to, value, data, operation, 0, 0, 0, ADDRESS_0, ADDRESS_0, nonce)
+        let sigs = utils.signTransaction(lw, [lw.accounts[0], lw.accounts[1]], transactionHash)
+        utils.logGasUsage(
+            'execTransaction ' + message,
+            await gnosisSafe.execTransaction(to, value, data, operation, 0, 0, 0, ADDRESS_0, ADDRESS_0, sigs, { from: accounts[0] })
+        )
+    }
+
+    it('Add delegates and remove first delegate', async () => {
+        let enableModuleData = await gnosisSafe.contract.methods.enableModule(safeModule.address).encodeABI()
+        await execTransaction(gnosisSafe.address, 0, enableModuleData, CALL, "enable module")
+        let modules = await gnosisSafe.getModules()
+        assert.equal(1, modules.length)
+        assert.equal(safeModule.address, modules[0])
+
+        // Add delegates
+        let addDelegateData = await safeModule.contract.methods.addDelegate(lw.accounts[4]).encodeABI()
+        await execTransaction(safeModule.address, 0, addDelegateData, CALL, "add delegate 1")
+
+        let addDelegateData2 = await safeModule.contract.methods.addDelegate(lw.accounts[5]).encodeABI()
+        await execTransaction(safeModule.address, 0, addDelegateData2, CALL, "add delegate 2")
+
+        let delegates = await safeModule.getDelegates(gnosisSafe.address, 0, 10)
+        assert.equal(2, delegates.results.length)
+        assert.equal(lw.accounts[5], delegates.results[0].toLowerCase())
+        assert.equal(lw.accounts[4], delegates.results[1].toLowerCase())
+
+        // Remove delegate
+        let removeDelegateData = await safeModule.contract.methods.removeDelegate(lw.accounts[5], true).encodeABI()
+        await execTransaction(safeModule.address, 0, removeDelegateData, CALL, "remove delegate 2")
+        delegates = await safeModule.getDelegates(gnosisSafe.address, 0, 10)
+        assert.equal(1, delegates.results.length)
+        assert.equal(lw.accounts[4], delegates.results[0].toLowerCase())
+    })
+
+    it('Add delegates and remove second delegate', async () => {
+        let enableModuleData = await gnosisSafe.contract.methods.enableModule(safeModule.address).encodeABI()
+        await execTransaction(gnosisSafe.address, 0, enableModuleData, CALL, "enable module")
+        let modules = await gnosisSafe.getModules()
+        assert.equal(1, modules.length)
+        assert.equal(safeModule.address, modules[0])
+
+        // Add delegates
+        let addDelegateData = await safeModule.contract.methods.addDelegate(lw.accounts[4]).encodeABI()
+        await execTransaction(safeModule.address, 0, addDelegateData, CALL, "add delegate 1")
+
+        let addDelegateData2 = await safeModule.contract.methods.addDelegate(lw.accounts[5]).encodeABI()
+        await execTransaction(safeModule.address, 0, addDelegateData2, CALL, "add delegate 2")
+
+        let delegates = await safeModule.getDelegates(gnosisSafe.address, 0, 10)
+        assert.equal(2, delegates.results.length)
+        assert.equal(lw.accounts[5], delegates.results[0].toLowerCase())
+        assert.equal(lw.accounts[4], delegates.results[1].toLowerCase())
+
+        // Remove delegate
+        let removeDelegateData = await safeModule.contract.methods.removeDelegate(lw.accounts[4], true).encodeABI()
+        await execTransaction(safeModule.address, 0, removeDelegateData, CALL, "remove delegate 1")
+        delegates = await safeModule.getDelegates(gnosisSafe.address, 0, 10)
+        assert.equal(1, delegates.results.length)
+        assert.equal(lw.accounts[5], delegates.results[0].toLowerCase())
+    })
+
+    it('Add and remove delegate then try to execute', async () => {
+        const token = await TestToken.new({from: accounts[0]})
+        await token.transfer(gnosisSafe.address, 1000, {from: accounts[0]}) 
+        
+        let enableModuleData = await gnosisSafe.contract.methods.enableModule(safeModule.address).encodeABI()
+        await execTransaction(gnosisSafe.address, 0, enableModuleData, CALL, "enable module")
+        let modules = await gnosisSafe.getModules()
+        assert.equal(1, modules.length)
+        assert.equal(safeModule.address, modules[0])
+
+        // Add delegates
+        let addDelegateData = await safeModule.contract.methods.addDelegate(lw.accounts[4]).encodeABI()
+        await execTransaction(safeModule.address, 0, addDelegateData, CALL, "add delegate 1")
+
+        let delegates = await safeModule.getDelegates(gnosisSafe.address, 0, 10)
+        assert.equal(1, delegates.results.length)
+        assert.equal(lw.accounts[4], delegates.results[0].toLowerCase())
+
+        // Add allowance 
+        let setAllowanceData = await safeModule.contract.methods.setAllowance(lw.accounts[4], token.address, 100, 0, 0).encodeABI()
+        await execTransaction(safeModule.address, 0, setAllowanceData, CALL, "set allowance")
+
+        // Remove delegate
+        let removeDelegateData = await safeModule.contract.methods.removeDelegate(lw.accounts[4], false).encodeABI()
+        await execTransaction(safeModule.address, 0, removeDelegateData, CALL, "remove delegate")
+        delegates = await safeModule.getDelegates(gnosisSafe.address, 0, 10)
+        assert.equal(0, delegates.results.length)
+
+        // Execute
+        assert.equal(1000, await token.balanceOf(gnosisSafe.address))
+        assert.equal(0, await token.balanceOf(accounts[1]))
+        let transferHash = await safeModule.generateTransferHash(
+            gnosisSafe.address, token.address, accounts[1], 60, ADDRESS_0, 0, 1
+        )
+        let signature = utils.signTransaction(lw, [lw.accounts[4]], transferHash)
+        await utils.assertRejects(
+            safeModule.executeAllowanceTransfer(
+                gnosisSafe.address, token.address, accounts[1], 60, ADDRESS_0, 0, lw.accounts[4], signature
+            ),
+            'executeAllowanceTransfer'
+        )
+
+        assert.equal(1000, await token.balanceOf(gnosisSafe.address))
+        assert.equal(0, await token.balanceOf(accounts[1]))
+    })
+
+    it('Use zero delegate', async () => {
+        const token = await TestToken.new({from: accounts[0]})
+        await token.transfer(gnosisSafe.address, 1000, {from: accounts[0]}) 
+        
+        let enableModuleData = await gnosisSafe.contract.methods.enableModule(safeModule.address).encodeABI()
+        await execTransaction(gnosisSafe.address, 0, enableModuleData, CALL, "enable module")
+        let modules = await gnosisSafe.getModules()
+        assert.equal(1, modules.length)
+        assert.equal(safeModule.address, modules[0])
+
+        // Add allowance 
+        let setAllowanceData = await safeModule.contract.methods.setAllowance(ADDRESS_0, token.address, 100, 0, 0).encodeABI()
+        await execTransaction(safeModule.address, 0, setAllowanceData, CALL, "set allowance")
+
+        // Execute
+        assert.equal(1000, await token.balanceOf(gnosisSafe.address))
+        assert.equal(0, await token.balanceOf(accounts[1]))
+        let signature = "0x".padEnd(130, "0") + "1c"
+        console.log(signature)
+        await utils.assertRejects(
+            safeModule.executeAllowanceTransfer(
+                gnosisSafe.address, token.address, accounts[1], 60, ADDRESS_0, 0, ADDRESS_0, signature
+            ),
+            'executeAllowanceTransfer'
+        )
+
+        assert.equal(1000, await token.balanceOf(gnosisSafe.address))
+        assert.equal(0, await token.balanceOf(accounts[1]))
+    })
+})


### PR DESCRIPTION
Reports:
1. `removeDelegate` doesn't update `delegatesStart` which will break the delegate linked list.
2. `removeDelegate` doesn't functionally remove the delegates, they can still have allowances and they can't be added back in with `addDelegate`. `removeDelegate` only affects the output of `getDelegates`
3. `ecrecover` returns 0 on failure, which will lead to this check passing, this isn't a security vulnerability if there are no allowances for the `0` address, but is still unexpected. https://github.com/gnosis/safe-modules/blob/master/allowances/contracts/AlowanceModule.sol#L241

Changes:
- Added tests for all reports
- Enforce that allowances cannot be set for the 0 address
- Enforce that delegates or their derived index cannot be the 0 address
- Enforce that the contract reverts on ecrecover failure
- Properly set `delegatesStart` if first element in linked list is removed