### PR TITLE
Version conflict with bitcore-lib 

### DIFF
--- a/recurring_transfers/package.json
+++ b/recurring_transfers/package.json
@@ -31,6 +31,7 @@
   "bugs": {
     "url": "https://github.com/gnosis/safe-modules/issues"
   },
+  "resolutions": { "bitcore-lib": "0.15.0" },
   "devDependencies": {
     "@digix/tempo": "^0.2.0",
     "@gnosis.pm/truffle-nice-tools": "^1.3.0",


### PR DESCRIPTION
Fixes issue: #28 

It looks like `eth-lightwallet@^3.0.1`
depends on: 
`bitcore-lib "^0.15.0"` and
`bitcore-mnemonic "^1.5.0"`

While `bitcore-mnemonic "^1.5.0"` depends on:
`bitcore-lib "^0.16.0 `

This conflict can be resolved with this PR. Either version 0.15.0 or 0.16.0 can be used as resolutions.